### PR TITLE
Fix off by one error when looking up command, and other minor changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ void addInt(String opts) {
 
 void setup() {
 	term = new maschinendeck::SerialTerminal(38400);
-	term->add("add", &addInt, "adds to integers");
+	term->add("add", &addInt, "adds two integers");
 }
 
 void loop() {
@@ -33,6 +33,7 @@ You can change the behavior of the library, by setting some flags:
 
 * `ST_FLAG_NOHELP` - removes the help screen normally printed on startup
 * `ST_FLAG_NOBUILTIN` - removes all default commands, if you do not need them
+* `ST_FLAG_NOPROMPT` - do not print a prompt
 
 You simply define them before the include of `SerialTerminal.h`:
 

--- a/SerialTerminal.hpp
+++ b/SerialTerminal.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#define ST_VERSION "1.0.2"
+#define ST_VERSION "1.0.3"
 
 #include <Arduino.h>
 
@@ -142,7 +142,7 @@ namespace maschinendeck {
         Pair<String, String> command = SerialTerminal::ParseCommand(this->message);
         this->message = "";
 
-        for (uint8_t i = 0; i <= this->size_; i++) {
+        for (uint8_t i = 0; i < this->size_; i++) {
           if (this->commands[i]->command == command.first()) {
             this->commands[i]->callback(command.second());
           }

--- a/SerialTerminal.hpp
+++ b/SerialTerminal.hpp
@@ -121,9 +121,16 @@ namespace maschinendeck {
             }
             if (isAscii(car))
                 Serial.print(car);
+            // Check if user ended the line
             if (car == '\r') {
                 Serial.print("\r\n");
                 commandComplete = true;
+                // If there are more data on the line, drop a \n, if it is
+                // there. Some terminals may send both, giving 
+                // an extra lineend, if we do not drop it.
+                if (Serial.available() && Serial.peek() == '\n') {
+                    Serial.read();
+                }
                 break;
             }
             this->message += car;
@@ -142,12 +149,22 @@ namespace maschinendeck {
         Pair<String, String> command = SerialTerminal::ParseCommand(this->message);
         this->message = "";
 
+        #ifndef ST_FLAG_NOPROMPT
+        bool found = false;
+        #endif
         for (uint8_t i = 0; i < this->size_; i++) {
           if (this->commands[i]->command == command.first()) {
             this->commands[i]->callback(command.second());
+            #ifndef ST_FLAG_NOPROMPT
+            found = true;
+            #endif
           }
         }
         #ifndef ST_FLAG_NOPROMPT
+        if (!found) {
+            Serial.print(command.first());
+            Serial.print(": command not found");
+        }
         Serial.print("\r\nst> ");
         #endif
       }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SerialTerminalPRO
-version=1.0.2
+version=1.0.3
 author=Michael Ochmann <miko@massivedynamic.eu>
 maintainer=Michael Ochmann <miko@massivedynamic.eu>
 sentence=a simple Arduino library to incorporate a serial terminal to your project


### PR DESCRIPTION
This fixes an off-by-one error when looking up a command.
Adds some information about the flag for the prompt to the readme.
Bumps the version number to 1.0.3
Last commits fixes not printing two lines when the user terminal uses \r\n for lineendings, and outpus "command not found", if a command is not found.

Please merge, and maybe release as 1.0.3.